### PR TITLE
Fix to refresh screen when switching disk by key

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -382,23 +382,31 @@ int main()
 		{
 			case KEY_HOME:
 				select = 0;
+				clear();
+				refresh();
 				update();
 				break;
 
 			case KEY_END:
 				select = static_cast<int>(smartList.size()) - 1;
+				clear();
+				refresh();
 				update();
 				break;
 
 			case KEY_LEFT:
 			case 'h':
 				select = std::max(select - 1, 0);
+				clear();
+				refresh();
 				update();
 				break;
 
 			case KEY_RIGHT:
 			case 'l':
 				select = std::min(select + 1, static_cast<int>(smartList.size()) - 1);
+				clear();
+				refresh();
 				update();
 				break;
 


### PR DESCRIPTION
My disks have different length of S.M.A.R.T info.
So, if I switch from "sda" to "sdb", "sda" info is remaining under "sdb" info in screen.

![crazy_screen_refresh_01](https://cloud.githubusercontent.com/assets/210614/22143630/0bdcaa4e-df3e-11e6-8901-8c7ed5c61c96.png)
![crazy_screen_refresh_02](https://cloud.githubusercontent.com/assets/210614/22143634/0dda38fc-df3e-11e6-82d0-74fb6136ee0f.png)

This PR is fixing it.