### PR TITLE
Clear window for removing remaining color

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -448,8 +448,11 @@ int main()
 	update = [&]()
 	{
 		getmaxyx(stdscr, height, width);
+		wclear(windowVersion);
 		drawVersion(windowVersion);
+		wclear(windowDeviceBar);
 		drawDeviceBar(windowDeviceBar, smartList, select);
+		wclear(windowDeviceStatus);
 		drawStatus(windowDeviceStatus, smartList[select]);
 		doupdate();
 	};


### PR DESCRIPTION
When we switch disk, some parts of status are changed.
With the status change, color are also changed but sometime remaining old color.
For fixing it, this commit is adding wclear() for each window.

Following is a sample image of remaining color. (the red part)
![crazy_temperature_03](https://cloud.githubusercontent.com/assets/210614/22190778/20533182-e169-11e6-88e5-1a873d99574a.png)
