### PR TITLE
For avoiding crash, exit with error message if no devices or non-root user

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -431,8 +431,8 @@ int main()
 	if (smartList.size() == 0)
 	{
 		endwin();
-		std::cout << "No S.M.A.R.T readable devices." << std::endl;
-		std::cout << "If you are non-root user, please use sudo or become root." << std::endl;
+		std::cerr << "No S.M.A.R.T readable devices." << std::endl;
+		std::cerr << "If you are non-root user, please use sudo or become root." << std::endl;
 		return 1;
 	}
 

--- a/main.cpp
+++ b/main.cpp
@@ -428,6 +428,14 @@ int main()
 	}
 	std::sort(smartList.begin(), smartList.end(), [](auto lhs, auto rhs){return lhs.deviceName < rhs.deviceName;});
 
+	if (smartList.size() == 0)
+	{
+		endwin();
+		std::cout << "No S.M.A.R.T readable devices." << std::endl;
+		std::cout << "If you are non-root user, please use sudo or become root." << std::endl;
+		return 1;
+	}
+
 	WINDOW * windowVersion;
 	windowVersion = newwin(1, width, 0, 0);
 
@@ -503,4 +511,3 @@ int main()
 		}
 	}
 }
-


### PR DESCRIPTION
If there is no S.M.A.R.T. readable devices, CrazyDiskInfo will crash.
"No S.M.A.R.T. readable devices" situation seems to be following.

- User doesn't have enough privileges same level as root (CAP_SYS_RAWIO to the command and read permission to each device files)
- There is no S.M.A.R.T. devices for real